### PR TITLE
feat(tui): M5-B.3c'' Compact Timeline Format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,6 +1425,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "tokio",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ crossterm = "0.28"
 arboard = "3.4"
 pulldown-cmark = "0.10"
 textwrap = "0.16"
+unicode-width = "0.2"
 
 # CLI dependencies
 clap = { version = "4.0", features = ["derive"] }

--- a/crates/ralf-tui/Cargo.toml
+++ b/crates/ralf-tui/Cargo.toml
@@ -17,6 +17,7 @@ chrono.workspace = true
 arboard.workspace = true
 pulldown-cmark.workspace = true
 textwrap.workspace = true
+unicode-width.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/ralf-tui/src/conversation/widget.rs
+++ b/crates/ralf-tui/src/conversation/widget.rs
@@ -166,7 +166,6 @@ impl<'a> ConversationPane<'a> {
 
             let mut lines: Vec<Line<'_>> = Vec::new();
             let mut current_line_spans: Vec<Span<'_>> = Vec::new();
-            let mut is_first_line = true;
             let mut cursor_drawn = false;
 
             // Add prompt to first line
@@ -186,15 +185,9 @@ impl<'a> ConversationPane<'a> {
                 }
 
                 if ch == '\n' {
-                    // End current line
+                    // End current line and start a new one with indentation
                     lines.push(Line::from(current_line_spans));
-                    current_line_spans = Vec::new();
-
-                    // Continuation lines get indentation
-                    if is_first_line {
-                        is_first_line = false;
-                    }
-                    current_line_spans.push(Span::raw(" ".repeat(prompt_len)));
+                    current_line_spans = vec![Span::raw(" ".repeat(prompt_len))];
                 } else {
                     current_line_spans.push(Span::styled(
                         ch.to_string(),

--- a/crates/ralf-tui/src/conversation/widget.rs
+++ b/crates/ralf-tui/src/conversation/widget.rs
@@ -50,6 +50,8 @@ pub struct ConversationPane<'a> {
     canvas_shows_spec: bool,
     /// Tick counter for animations.
     tick: usize,
+    /// Whether to use ASCII-only symbols.
+    ascii_mode: bool,
 }
 
 impl<'a> ConversationPane<'a> {
@@ -67,6 +69,7 @@ impl<'a> ConversationPane<'a> {
             focused: false,
             canvas_shows_spec: false,
             tick: 0,
+            ascii_mode: false,
         }
     }
 
@@ -80,6 +83,7 @@ impl<'a> ConversationPane<'a> {
             focused: false,
             canvas_shows_spec: false,
             tick: 0,
+            ascii_mode: false,
         }
     }
 
@@ -110,6 +114,13 @@ impl<'a> ConversationPane<'a> {
     #[must_use]
     pub fn tick(mut self, tick: usize) -> Self {
         self.tick = tick;
+        self
+    }
+
+    /// Set whether to use ASCII-only symbols.
+    #[must_use]
+    pub fn ascii_mode(mut self, ascii: bool) -> Self {
+        self.ascii_mode = ascii;
         self
     }
 
@@ -259,7 +270,8 @@ impl Widget for ConversationPane<'_> {
                 .with_border(false)
                 .focused(self.focused)
                 .canvas_shows_spec(self.canvas_shows_spec)
-                .tick(self.tick);
+                .tick(self.tick)
+                .ascii_mode(self.ascii_mode);
             timeline_widget.render(inner, buf);
             return;
         }
@@ -287,7 +299,8 @@ impl Widget for ConversationPane<'_> {
             .with_border(false)
             .focused(self.focused)
             .canvas_shows_spec(self.canvas_shows_spec)
-            .tick(self.tick);
+            .tick(self.tick)
+            .ascii_mode(self.ascii_mode);
         timeline_widget.render(timeline_area, buf);
 
         // Render divider

--- a/crates/ralf-tui/src/layout/shell.rs
+++ b/crates/ralf-tui/src/layout/shell.rs
@@ -201,6 +201,7 @@ fn render_main_area(
             timeline_bounds,
             false, // Canvas not visible
             tick,
+            ascii_mode,
         );
         return;
     }
@@ -227,6 +228,7 @@ fn render_main_area(
                 timeline_bounds,
                 canvas_shows_spec,
                 tick,
+                ascii_mode,
             );
             render_context_pane(
                 frame,
@@ -253,6 +255,7 @@ fn render_main_area(
                 timeline_bounds,
                 false, // Canvas not visible in focus mode
                 tick,
+                ascii_mode,
             );
         }
         ScreenMode::ContextFocus => {
@@ -285,6 +288,7 @@ fn render_timeline_pane(
     timeline_bounds: &mut TimelinePaneBounds,
     canvas_shows_spec: bool,
     tick: usize,
+    ascii_mode: bool,
 ) {
     // Calculate inner area (accounting for 1-pixel border on all sides)
     // This is used for mouse coordinate translation
@@ -296,7 +300,8 @@ fn render_timeline_pane(
     let widget = ConversationPane::from_timeline(timeline, theme)
         .focused(focused)
         .canvas_shows_spec(canvas_shows_spec)
-        .tick(tick);
+        .tick(tick)
+        .ascii_mode(ascii_mode);
     frame.render_widget(widget, area);
 }
 

--- a/crates/ralf-tui/src/text/mod.rs
+++ b/crates/ralf-tui/src/text/mod.rs
@@ -4,11 +4,14 @@
 //! - [`render_markdown`] - Render markdown to styled ratatui Lines
 //! - [`MarkdownStyles`] - Style configuration for markdown elements
 //! - [`wrap_text`], [`wrap_lines`] - Text wrapping utilities
+//! - [`visual_width`], [`truncate_to_width`] - Unicode-aware width utilities
 
 mod markdown;
 mod styles;
+mod width;
 mod wrap;
 
 pub use markdown::render_markdown;
 pub use styles::MarkdownStyles;
+pub use width::{truncate_to_width, visual_width};
 pub use wrap::{wrap_lines, wrap_text};

--- a/crates/ralf-tui/src/text/width.rs
+++ b/crates/ralf-tui/src/text/width.rs
@@ -1,0 +1,104 @@
+//! Text width and truncation utilities.
+//!
+//! Provides unicode-aware text width calculation and safe truncation.
+
+use unicode_width::UnicodeWidthStr;
+
+/// Get the visual width of a string in terminal cells.
+///
+/// Accounts for wide characters (CJK, emoji) that take 2 cells.
+pub fn visual_width(s: &str) -> usize {
+    UnicodeWidthStr::width(s)
+}
+
+/// Truncate a string to fit within a maximum visual width.
+///
+/// Returns the truncated string with "..." appended if truncation occurred.
+/// This is unicode-safe and respects character boundaries.
+pub fn truncate_to_width(s: &str, max_width: usize) -> String {
+    let current_width = visual_width(s);
+    if current_width <= max_width {
+        return s.to_string();
+    }
+
+    // Need to truncate - account for "..." suffix (3 chars)
+    let target_width = max_width.saturating_sub(3);
+    if target_width == 0 {
+        return "...".to_string();
+    }
+
+    let mut result = String::new();
+    let mut width = 0;
+
+    for ch in s.chars() {
+        let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + ch_width > target_width {
+            break;
+        }
+        result.push(ch);
+        width += ch_width;
+    }
+
+    result.push_str("...");
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_visual_width_ascii() {
+        assert_eq!(visual_width("hello"), 5);
+        assert_eq!(visual_width(""), 0);
+    }
+
+    #[test]
+    fn test_visual_width_wide_chars() {
+        // CJK characters are 2 cells wide
+        assert_eq!(visual_width("你好"), 4);
+        assert_eq!(visual_width("hello你好"), 9);
+    }
+
+    #[test]
+    fn test_visual_width_emoji() {
+        // Basic emoji - width varies by terminal, but generally 2
+        let width = visual_width("🎉");
+        assert!(width >= 1 && width <= 2);
+    }
+
+    #[test]
+    fn test_truncate_no_truncation_needed() {
+        assert_eq!(truncate_to_width("hello", 10), "hello");
+        assert_eq!(truncate_to_width("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_truncate_ascii() {
+        assert_eq!(truncate_to_width("hello world", 8), "hello...");
+    }
+
+    #[test]
+    fn test_truncate_unicode_safe() {
+        // Should not panic on unicode
+        let result = truncate_to_width("你好世界", 5);
+        assert!(result.ends_with("..."));
+        // Should have at least one Chinese char before ...
+        assert!(result.chars().next().unwrap() == '你');
+    }
+
+    #[test]
+    fn test_truncate_very_short() {
+        assert_eq!(truncate_to_width("hello", 3), "...");
+        assert_eq!(truncate_to_width("hello", 0), "...");
+    }
+
+    #[test]
+    fn test_truncate_emoji_boundary() {
+        // Should not split emoji
+        let result = truncate_to_width("🎉🎊🎁 celebration", 10);
+        assert!(!result.is_empty());
+        // Should end with ...
+        assert!(result.ends_with("..."));
+    }
+}

--- a/crates/ralf-tui/src/timeline/event.rs
+++ b/crates/ralf-tui/src/timeline/event.rs
@@ -71,13 +71,13 @@ impl TimelineEvent {
     /// Returns:
     /// - `›` for user messages
     /// - `●` for coordinator AI (Spec, Run)
-    /// - `◦` for collaborator AI (Review)
+    /// - `○` for collaborator AI (Review)
     /// - `!` for system messages
     pub fn speaker_symbol(&self) -> &'static str {
         match &self.kind {
-            EventKind::Spec(e) if e.is_user => "\u{203a}", // ›
-            EventKind::Spec(_) | EventKind::Run(_) => "\u{25cf}", // ●
-            EventKind::Review(_) => "\u{25cb}",            // ◦
+            EventKind::Spec(e) if e.is_user => "›",
+            EventKind::Spec(_) | EventKind::Run(_) => "●",
+            EventKind::Review(_) => "○",
             EventKind::System(_) => "!",
         }
     }
@@ -137,8 +137,8 @@ impl TimelineEvent {
             }
             EventKind::Review(e) => {
                 let icon = match e.result {
-                    ReviewResult::Passed => "\u{2713}", // ✓
-                    ReviewResult::Failed => "\u{2717}", // ✗
+                    ReviewResult::Passed => "✓",
+                    ReviewResult::Failed => "✗",
                     ReviewResult::Skipped => "-",
                 };
                 format!("{} {}", icon, e.criterion)
@@ -497,7 +497,7 @@ mod tests {
             EventKind::Review(ReviewEvent::new("Tests pass", ReviewResult::Passed)),
         );
         assert_eq!(event.badge(), "REVIEW");
-        assert!(event.summary().contains('\u{2713}')); // ✓
+        assert!(event.summary().contains('✓'));
         assert!(event.summary().contains("Tests pass"));
     }
 
@@ -507,7 +507,7 @@ mod tests {
             5,
             EventKind::Review(ReviewEvent::new("Lint clean", ReviewResult::Failed)),
         );
-        assert!(event.summary().contains('\u{2717}')); // ✗
+        assert!(event.summary().contains('✗'));
     }
 
     #[test]

--- a/crates/ralf-tui/src/timeline/event.rs
+++ b/crates/ralf-tui/src/timeline/event.rs
@@ -56,13 +56,53 @@ impl TimelineEvent {
         local.format("%H:%M").to_string()
     }
 
-    /// Get the badge text for this event.
+    /// Get the badge text for this event (legacy, for tests).
     pub fn badge(&self) -> &'static str {
         match &self.kind {
             EventKind::Spec(_) => "SPEC",
             EventKind::Run(_) => "RUN",
             EventKind::Review(_) => "REVIEW",
             EventKind::System(_) => "SYS",
+        }
+    }
+
+    /// Get the speaker symbol for compact display.
+    ///
+    /// Returns:
+    /// - `›` for user messages
+    /// - `●` for coordinator AI (Spec, Run)
+    /// - `◦` for collaborator AI (Review)
+    /// - `!` for system messages
+    pub fn speaker_symbol(&self) -> &'static str {
+        match &self.kind {
+            EventKind::Spec(e) if e.is_user => "\u{203a}", // ›
+            EventKind::Spec(_) | EventKind::Run(_) => "\u{25cf}", // ●
+            EventKind::Review(_) => "\u{25cb}",            // ◦
+            EventKind::System(_) => "!",
+        }
+    }
+
+    /// Get the speaker symbol for ASCII mode.
+    pub fn speaker_symbol_ascii(&self) -> &'static str {
+        match &self.kind {
+            EventKind::Spec(e) if e.is_user => ">",
+            EventKind::Spec(_) | EventKind::Run(_) => "*",
+            EventKind::Review(_) => "o",
+            EventKind::System(_) => "!",
+        }
+    }
+
+    /// Check if this event is from the user.
+    pub fn is_user(&self) -> bool {
+        matches!(&self.kind, EventKind::Spec(e) if e.is_user)
+    }
+
+    /// Get the model name for attribution (AI events only).
+    pub fn model_attribution(&self) -> Option<String> {
+        match &self.kind {
+            EventKind::Spec(e) => e.model.clone(),
+            EventKind::Run(e) => Some(format!("{} #{}", e.model, e.iteration)),
+            EventKind::Review(_) | EventKind::System(_) => None,
         }
     }
 

--- a/crates/ralf-tui/src/timeline/event.rs
+++ b/crates/ralf-tui/src/timeline/event.rs
@@ -102,7 +102,8 @@ impl TimelineEvent {
         match &self.kind {
             EventKind::Spec(e) => e.model.clone(),
             EventKind::Run(e) => Some(format!("{} #{}", e.model, e.iteration)),
-            EventKind::Review(_) | EventKind::System(_) => None,
+            EventKind::Review(e) => e.model.clone(),
+            EventKind::System(_) => None,
         }
     }
 
@@ -324,6 +325,8 @@ pub struct ReviewEvent {
     pub result: ReviewResult,
     /// Optional details.
     pub details: Option<String>,
+    /// Model that performed the review.
+    pub model: Option<String>,
 }
 
 impl ReviewEvent {
@@ -333,6 +336,21 @@ impl ReviewEvent {
             criterion: criterion.into(),
             result,
             details: None,
+            model: None,
+        }
+    }
+
+    /// Create a review event with model attribution.
+    pub fn with_model(
+        criterion: impl Into<String>,
+        result: ReviewResult,
+        model: impl Into<String>,
+    ) -> Self {
+        Self {
+            criterion: criterion.into(),
+            result,
+            details: None,
+            model: Some(model.into()),
         }
     }
 
@@ -346,6 +364,22 @@ impl ReviewEvent {
             criterion: criterion.into(),
             result,
             details: Some(details.into()),
+            model: None,
+        }
+    }
+
+    /// Create a review event with model and details.
+    pub fn with_model_and_details(
+        criterion: impl Into<String>,
+        result: ReviewResult,
+        model: impl Into<String>,
+        details: impl Into<String>,
+    ) -> Self {
+        Self {
+            criterion: criterion.into(),
+            result,
+            details: Some(details.into()),
+            model: Some(model.into()),
         }
     }
 }

--- a/crates/ralf-tui/src/timeline/widget.rs
+++ b/crates/ralf-tui/src/timeline/widget.rs
@@ -165,23 +165,15 @@ impl<'a> TimelineWidget<'a> {
         let force_collapse = self.canvas_shows_spec && is_assistant_spec;
         let effectively_collapsed = event.collapsed || force_collapse;
 
-        // Collapse/expand indicator (ASCII: > and v)
-        let (collapsed_icon, expanded_icon) = if self.ascii_mode {
-            (">", "v")
-        } else {
-            ("\u{25b8}", "\u{25be}") // ▸ ▾
-        };
-
-        let collapse_indicator = if event.is_collapsible() {
-            if effectively_collapsed {
-                collapsed_icon
-            } else {
-                expanded_icon
+        // Collapse/expand indicator
+        let collapse_indicator = match (event.is_collapsible(), effectively_collapsed, selected) {
+            (true, true, _) | (false, _, true) => {
+                if self.ascii_mode { ">" } else { "▸" }
             }
-        } else if selected {
-            collapsed_icon
-        } else {
-            " "
+            (true, false, _) => {
+                if self.ascii_mode { "v" } else { "▾" }
+            }
+            (false, _, false) => " ",
         };
 
         // Speaker symbol and color


### PR DESCRIPTION
## Summary

- Redesigns timeline event rendering to be compact and conversation-focused (inspired by Claude Code)
- Single-line format with symbol-based speaker identification
- Removes verbose `[SPEC]`/`[RUN]` badge lines
- Right-aligned model attribution for AI events

### New Format Examples

**User message:** `› Help me implement...`

**AI message:** `● I'll help you...              claude`

**Review:** `◦ ✓ Tests pass                     gemini`

**System:** `! Model rate limited`

## Test plan

- [x] `cargo build` compiles without errors
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` - all 386 tests pass
- [ ] Visual testing in TUI
- [ ] Verify selection highlighting works
- [ ] Verify collapse/expand with Enter
- [ ] Verify copy with `y`

## Spec

See `docs/planning/SPEC-m5b3c-double-prime-compact-timeline.md`